### PR TITLE
Allow add-ons to have localized display panes titles

### DIFF
--- a/components/displaypanes/src/sbDisplayPanes.js
+++ b/components/displaypanes/src/sbDisplayPanes.js
@@ -22,9 +22,12 @@
 // END NIGHTINGALE GPL
 //
 
+const CHROME_PREFIX = "chrome://"
+
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 Components.utils.import("resource://app/jsmodules/ArrayConverter.jsm");
 Components.utils.import("resource://app/jsmodules/RDFHelper.jsm");
+Components.utils.import("resource://app/jsmodules/StringUtils.jsm");
 
 /**
  * sbIContentPaneInfo
@@ -139,7 +142,18 @@ DisplayPaneMetadataReader.prototype = {
           addon.Value + " due to these error(s):\n", errorList);
       return;
     }
-    
+
+    // Resolve any localised display pane contentTitle to their actual strings
+    if (info.contentTitle.substr(0,CHROME_PREFIX.length) == CHROME_PREFIX)
+    {
+      var contentTitle = SBString("displaypanes.contenttitle.unnamed");
+      var split = info.contentTitle.split("#", 2);
+      if (split.length == 2) {
+        var bundle = new SBStringBundle(split[0]);
+        contentTitle = bundle.get(split[1], contentTitle);
+      }
+      info.contentTitle = contentTitle;
+    }     
     // Submit description
     this._manager.registerContent( info.contentUrl, 
                                    info.contentTitle,

--- a/extensions/AlbumArt/install.rdf.in
+++ b/extensions/AlbumArt/install.rdf.in
@@ -43,7 +43,7 @@
     <nightingale:displayPane>
         <Description>
             <nightingale:contentUrl>chrome://albumart/content/albumArtPane.xul</nightingale:contentUrl>
-            <nightingale:contentTitle>Artwork</nightingale:contentTitle>
+            <nightingale:contentTitle>chrome://nightingale/locale/nightingale.properties#albumart.displaypane.title</nightingale:contentTitle>
             <nightingale:contentIcon>chrome://albumart/skin/icon-albumart.png</nightingale:contentIcon>
             <nightingale:defaultWidth>178</nightingale:defaultWidth>
             <nightingale:defaultHeight>178</nightingale:defaultHeight>

--- a/locales/en-US/nightingale/nightingale.properties
+++ b/locales/en-US/nightingale/nightingale.properties
@@ -1361,3 +1361,5 @@ cdinfo.details.closed=See Details
 feathers.name.unnamed=Unnamed Layout
 feathers.name.mainlayout=Main Player
 feathers.name.minilayout=Mini Player
+
+displaypanes.contenttitle.unnamed=Unnamed Pane


### PR DESCRIPTION
This is from an upstream patch here (not yet reviewed) :
http://bugzilla.songbirdnest.com/show_bug.cgi?id=24938
