### PR TITLE
Backport SB Bug 21745

### DIFF
--- a/components/mediacore/manager/src/sbMediacoreSequencer.cpp
+++ b/components/mediacore/manager/src/sbMediacoreSequencer.cpp
@@ -1615,8 +1615,11 @@ sbMediacoreSequencer::Setup(nsIURI *aURI /*= nsnull*/)
       nsCOMPtr<sbIMediacorePlaybackControl> playbackControl = mPlaybackControl;
       mon.Exit();
 
-      rv = UpdateLastPositionProperty(lastItem, nsnull);
-      NS_ENSURE_SUCCESS(rv, rv);
+      // If we played an Item, update it. If we played an url (no Item in Library), we skip this part.
+      if (lastItem){
+        rv = UpdateLastPositionProperty(lastItem, nsnull);
+        NS_ENSURE_SUCCESS(rv, rv);
+      }
 
       rv = playbackControl->Stop();
       NS_ASSERTION(NS_SUCCEEDED(rv),


### PR DESCRIPTION
Calling playURLfails when there is a URL playing already

If there is a URL (not an item of the Library) playing, a call to playURL fails. For this it doesn't matter if the urls are similar or different.
