### PR TITLE
Remove duplicate preferences menu entry on Linux

### DIFF
--- a/app/content/xul/linuxMenuOverlay.xul
+++ b/app/content/xul/linuxMenuOverlay.xul
@@ -55,6 +55,13 @@
                   oncommand="openPreferences();"/>
       </menupopup>
     </menu>
+    <!-- remove preferences entry in Tools menu, see SB bug #10030 -->
+    <menu id="tools-menu">
+      <menupopup id="menu_ToolsPopup">
+        <menuseparator id="menu_PrefsSeparator" removeelement="true"/>
+        <menuitem id="menu_preferences" removeelement="true"/>
+      </menupopup>
+    </menu>
   </menubar>
 
   <!-- XXXredfive this make ctrl-shift-z work but doens't block ctrl-y -->


### PR DESCRIPTION
Linux had two entries for accessing the preferences (in Tools and in Edit). In Linux, default is the Edit menu (see SB bug: http://bugzilla.songbirdnest.com/show_bug.cgi?id=10030).
This patch removes the entry in the Tools menu.
Will be ported to SB as well.

And I hope the indentation is ok now :-)
