### PR TITLE
Media-import warning has default value to not be displayed again

### DIFF
--- a/app/content/xul/mediaimportWarningDialog.xul
+++ b/app/content/xul/mediaimportWarningDialog.xul
@@ -118,7 +118,7 @@
     
     <!-- Dialog enable checkbox. -->
     <checkbox id="dialog_enable"
-              checked="true"
+              checked="false"
               label="&mediaimporter.filtered_extensions.dontshowme;" />
 
   </vbox>


### PR DESCRIPTION
When importing media that uses a codec not present on the system, NG displays an warning dialog. The default value of the checkbox is to not show the dialog again, which is not common.
The patches changes the default value to show the dialog again.
