### PR TITLE
Unable to clear downloads list in download manager

### DIFF
--- a/app/content/scripts/playerOpen.js
+++ b/app/content/scripts/playerOpen.js
@@ -574,19 +574,7 @@ function SBOpenPreferences(paneID, parentWindow)
 
 function SBOpenDownloadManager()
 {
-  var dlmgr = Components.classes['@mozilla.org/download-manager;1'].getService();
-  dlmgr = dlmgr.QueryInterface(Components.interfaces.nsIDownloadManager);
-
-  var windowMediator = Components.classes['@mozilla.org/appshell/window-mediator;1'].getService();
-  windowMediator = windowMediator.QueryInterface(Components.interfaces.nsIWindowMediator);
-
-  var dlmgrWindow = windowMediator.getMostRecentWindow("Download:Manager");
-  if (dlmgrWindow) {
-    dlmgrWindow.focus();
-  }
-  else {
-    window.open("chrome://mozapps/content/downloads/downloads.xul", "Download:Manager", "chrome,centerscreen,dialog=no,resizable", null);
-  }
+  Components.classes['@mozilla.org/download-manager-ui;1'].getService(Components.interfaces.nsIDownloadManagerUI).show(window);
 }
 
 function SBScanMedia( aParentWindow, aScanDirectory )


### PR DESCRIPTION
When clicking "Clear List" in the default download manager window, NG throws an error. The dialog should be opened differently (it seems as if it needed some sort of variable passed).

This pull request fixes the error (and reduces the code size by 644 bytes).
