### PR TITLE
fix for gstreamer lib locations on ubuntu 12.04 and typo fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,12 +42,12 @@ case $OSTYPE in
 		cd ../
 		
 		# use our own gstreamer libs
-		for dir in /usr/lib64 /usr/lib ; do
+		for dir in /usr/lib64 /usr/lib /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu; do
 			if [ -f ${dir}/gstreamer-0.10/libgstcoreelements.so ] ; then
 				export GST_PLUGIN_PATH=${dir}/gstreamer\-0.10
 				break
 			elif [ -f ${dir}/gstreamer0.10/libgstcoreelements.so ] ; then
-				export GST_PLUIN_PATH=${dir}/gstreamer0.10
+				export GST_PLUGIN_PATH=${dir}/gstreamer0.10
 				break
 			fi
 		done

--- a/installer/linux/nightingale.sh
+++ b/installer/linux/nightingale.sh
@@ -39,15 +39,28 @@
 #set -e
 #set -x
 
+# fix for Ubuntu 12.04	
+gstdirs="/usr/lib64 /usr/lib"
+
+if [ -f /etc/lsb-release && -n $(cat /etc/lsb-release | grep Ubuntu) ] ; then
+	if [ -n $(cat /etc/lsb-release | grep 12.04) ] ; then
+		if [ $(uname -m)==x86_64 ] ; then
+			gstdirs="/usr/lib/x86_64-linux-gnu /usr/lib64 /usr/lib"
+		elif [ $(uname -m)==i386 ] ; then
+			gstdirs="/usr/lib/i386-linux-gnu /usr/lib"
+		fi
+	fi
+fi
+
 # this depends on your system's gstreamer location
 # while sometimes, the make process actually uses the location properly
 # it doesn't always, and this is better than symlinking
-for dir in /usr/lib64 /usr/lib ; do
+for dir in $gstdirs ; do
   if [ -f ${dir}/gstreamer-0.10/libgstcoreelements.so ] ; then
     export GST_PLUGIN_PATH=${dir}/gstreamer\-0.10
     break
   elif [ -f ${dir}/gstreamer0.10/libgstcoreelements.so ] ; then
-	export GST_PLUIN_PATH=${dir}/gstreamer0.10
+	export GST_PLUGIN_PATH=${dir}/gstreamer0.10
 	break
   fi
 done


### PR DESCRIPTION
This is a fix for the new gstreamer lib locations on Ubuntu 12.04; also sending a pull request on the sb-trunk-oldxul branch for this as well. Completely cripples nightingale, even the released 1.8 builds. Can't play anything, nor import, nor open, etc.

Link to post in forum: http://forum.getnightingale.com/thread-419-post-1808.html#pid1808
