### PR TITLE
Fix for ubuntu playback & import issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ case $OSTYPE in
     cd ../
     
     # use our own gstreamer libs
-    for dir in /usr/lib /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu ; do
+    for dir in /usr/lib /usr/lib64 /usr/lib/$(uname -m|sed -e 's/.*64.*/x86_64/;/x86_64/!s/.*/i386/')-linux-gnu ; do
       if [ -f ${dir}/gstreamer-0.10/libgstcoreelements.so ] ; then
         export GST_PLUGIN_PATH=${dir}/gstreamer\-0.10
         break

--- a/installer/linux/nightingale.sh
+++ b/installer/linux/nightingale.sh
@@ -40,7 +40,7 @@
 #set -x
 
 # use our own gstreamer libs
-for dir in /usr/lib /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu ; do
+for dir in /usr/lib /usr/lib64 /usr/lib/$(uname -m|sed -e 's/.*64.*/x86_64/;/x86_64/!s/.*/i386/')-linux-gnu ; do
   if [ -f ${dir}/gstreamer-0.10/libgstcoreelements.so ] ; then
     export GST_PLUGIN_PATH=${dir}/gstreamer\-0.10
     break
@@ -49,7 +49,6 @@ for dir in /usr/lib /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu
     break
   fi
 done
-
 
 cmdname=`basename "$0"`
 MOZ_DIST_BIN=`dirname "$0"`


### PR DESCRIPTION
The problem seemed to be that x86_64 versions were using 32 bit gstreamer libs. I don't think that anyone using a 32 bit version of Ubuntu would have encountered this because of the way build.sh was previously, but even on a 64 bit version, there were still 32 bit gstreamer libs located in /usr/lib/i386-linux-gnu. This was making nightingale load those instead of the ones in /usr/lib/x86_64-linux-gnu.

This was a quick fix but it works, so I figured I'd send in a pull request before anyone wasted any time trying to debug it.
