### PR TITLE
Fixes UnityIntegration crash on Ubuntu 13.04

### DIFF
--- a/extensions/unity-integration/components/src/UnityProxy.cpp
+++ b/extensions/unity-integration/components/src/UnityProxy.cpp
@@ -91,7 +91,7 @@ NS_IMETHODIMP UnityProxy::InitializeFor (const char* desktopFileName, const char
 		playerName = g_key_file_get_string (keyFile, "Desktop Entry", "Name", NULL);
 		playerIcon = g_key_file_get_string (keyFile, "Desktop Entry", "Icon", NULL);
 	}
-	g_free (keyFile);
+	g_key_file_free (keyFile);
 	
 	if (!playerName || !playerIcon) return NS_ERROR_UNEXPECTED;
 	


### PR DESCRIPTION
GKeyFile should be freed in right way.
Don't know why g_free on GKeyFile worked before :)
