### PR TITLE
updated fix for issue #194, wma import problems under Mac OSX/Linux

### DIFF
--- a/components/mediacore/gstreamer/src/sbGStreamerMediacoreFactory.cpp
+++ b/components/mediacore/gstreamer/src/sbGStreamerMediacoreFactory.cpp
@@ -221,7 +221,7 @@ sbGStreamerMediacoreFactory::OnGetCapabilities(
 
     const char *extraAudioExtensions[] = {"m4r", "m4p", "oga",
                                           "ogg", "aac", "3gp"};
-#ifdef XP_WIN
+#if defined(XP_WIN) || defined(XP_UNIX)
     const char *extraWindowsAudioExtensions[] = {"wma" };
 #endif
 
@@ -329,7 +329,7 @@ sbGStreamerMediacoreFactory::OnGetCapabilities(
         audioExtensions.AppendElement(ext);
     }
 
-#if XP_WIN
+#if defined(XP_WIN) || defined(XP_UNIX)
     for (unsigned int i = 0; i < NS_ARRAY_LENGTH(extraWindowsAudioExtensions); i++) {
       nsString ext = NS_ConvertUTF8toUTF16(extraWindowsAudioExtensions[i]);
       if(!audioExtensions.Contains(ext))


### PR DESCRIPTION
As requested I removed the code that was using the const variable, thus preventing windows build to break.  Original pull request can be found here: https://github.com/nightingale-media-player/nightingale-hacking/pull/223 

Steps to verify if 'fix' worked correctly: 
1. Take some of .mp3's files and convert them to .wma using this website, http://media.io/
2. File > Import media, should add .wma to library properly.
3. File > Open File .. should also work correctly.
4. If you have Watch Folders option enabled, moving the .wma files into the watched directory or dragging the .wma file into the library view, should correctly import the .wma file into the library.
5. Playback should work.

We need someone to verify this on a mac!!! Please and thanks!

Thanks to @rsjtdrjgfuzkfg for helping out.
