### PR TITLE
Prevent Nightinggale from switching to the discrete GPU

### DIFF
--- a/app/Info.plist.in
+++ b/app/Info.plist.in
@@ -739,5 +739,7 @@
   <true/>
   <key>CGDisableCoalescedUpdates</key>
   <true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
When Nightingale starts to play music, the Macbook Pro switches to the discrete GPU and that drains unnecessary battery power. This should be prevented.

The addition of this key to Info.plist requires Mac OS X Lion or newer to have effect.
