### PR TITLE
Added build number generation [#255].

### DIFF
--- a/build/sbBuildInfo.mk.in
+++ b/build/sbBuildInfo.mk.in
@@ -6,7 +6,7 @@
 # 1.1-branch anymore.
 SB_APPNAME=Nightingale
 SB_BUILD_ID=20140803000000
-BuildNumber=2456
+BuildNumber=`git describe --long --always --dirty --abbrev=10`
 SB_BUILD_NUMBER=$(BuildNumber)
 SB_MILESTONE=1.13a
 SB_MILESTONE_WINDOWS=1.13.1


### PR DESCRIPTION
Build numbers are now generated from git. I'm not yet certain how portable this
solution is, though. Tested on Linux; not sure if this is compatible with
Windows and/or OSX.

It will certainly break / look terrible if the user has no git installed (we could work around this, but I think that is fine).

I'm not pushing directly, as I want somebody to test this on Windows and/or OSX first (or telling me to merge so it is not my fault if it breaks :P).