### PR TITLE
Fix Mac building by reporting mac as i686

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -276,8 +276,8 @@ case "$target" in
       powerpc* | ppc)
         SB_ARCH="ppc"
       ;;
-      *i*86*)
-        SB_ARCH="$target_cpu"
+      *i*86* | x86_64)
+        SB_ARCH="i686"
       ;;
       *)
         AC_MSG_ERROR(Unsupported architecture)


### PR DESCRIPTION
Fix Mac building by making config.guess report 32-bit and 64-bit macs as i686, as was the case before 3267acc. I guess this can be reverted at a later time, when someone tries to update the build process to use a newer XCode/build dependencies.
