### PR TITLE
Changed "it's" to "its" in the License Agreement and other places

### DIFF
--- a/app/content/bindings/browser/sbTabBrowser.xml
+++ b/app/content/bindings/browser/sbTabBrowser.xml
@@ -1245,7 +1245,7 @@
                                                               aPriority,
                                                               aButtons);
           } else {
-            // if there is a notification object set it's text.
+            // if there is a notification object set its text.
             // this has the side effect of showing it if it was dismissed
             notification.message = aMessage;
           }

--- a/app/content/html/eula.html.in
+++ b/app/content/html/eula.html.in
@@ -30,7 +30,7 @@
 
 <body>
 
-<p>Nightingale is a completely free and open source fork of the Songbird Media Player. Portions are Copyright POTI; however everything in this release is fully free and open. No warranties, guarantees, or expectations of any services whatsoever are to be provided by the Nightingale Community or it's members to any user of Nightingale. We do it because we love free software. By using this software, you agree not to sue us or use Nightingale for anything that could get us in trouble, legal or otherwise. Enjoy!
+<p>Nightingale is a completely free and open source fork of the Songbird Media Player. Portions are Copyright POTI; however everything in this release is fully free and open. No warranties, guarantees, or expectations of any services whatsoever are to be provided by the Nightingale Community or its members to any user of Nightingale. We do it because we love free software. By using this software, you agree not to sue us or use Nightingale for anything that could get us in trouble, legal or otherwise. Enjoy!
 
 </body>
 </html>

--- a/app/content/html/songbird-eula-text.html
+++ b/app/content/html/songbird-eula-text.html
@@ -30,7 +30,7 @@
 
 <body>
 
-<p>Nightingale is a completely free and opensource fork of the Songbird media player. Portions are copyright POTI; however everything in this release is fully free and open. No warranties, gurantees, or expectations of any services whatsoever are to be provided by the Nightingale Community or it's members to any user of Nightingale. We do it because we love free software. By using this software, you agree not to sue us or use Nightingale for anything that could get us in trouble, legal or otherwise. Enjoy!
+<p>Nightingale is a completely free and opensource fork of the Songbird media player. Portions are copyright POTI; however everything in this release is fully free and open. No warranties, gurantees, or expectations of any services whatsoever are to be provided by the Nightingale Community or its members to any user of Nightingale. We do it because we love free software. By using this software, you agree not to sue us or use Nightingale for anything that could get us in trouble, legal or otherwise. Enjoy!
 
 </body>
 </html>

--- a/build/config.mk
+++ b/build/config.mk
@@ -26,7 +26,7 @@
 # config.mk
 #
 # This file is included in rules.mk and contains variables not set by
-# autoconf. It's primary use is to set PPDEFINES, a list of definitions that
+# autoconf. Its primary use is to set PPDEFINES, a list of definitions that
 # are passed to the preprocessor.
 ###############################################################################
 

--- a/components/dbengine/src/DatabaseEngine.cpp
+++ b/components/dbengine/src/DatabaseEngine.cpp
@@ -2033,7 +2033,7 @@ PLDHashOperator CDatabaseEngine::EnumerateIntoArrayStringKey(
   nsTArray<nsString> *stringArray = 
     reinterpret_cast< nsTArray<nsString>* >(aArray);
   
-  // No need to lock the queue here since it's access to m_QueuePool is locked
+  // No need to lock the queue here since its access to m_QueuePool is locked
   // when we are enumerating it.
 
   if(aQueue->m_AnalyzeCount > ANALYZE_QUERY_THRESHOLD) {

--- a/components/devices/base/public/sbIDeviceFirmwareUpdater.idl
+++ b/components/devices/base/public/sbIDeviceFirmwareUpdater.idl
@@ -54,7 +54,7 @@ interface sbIDeviceFirmwareUpdater : nsISupports
    * \param aListener [optional] - Device listener to recieve events
    * \note The flow of events for this method is the following: 
    *       firmware check for update start, firmware check for update end. 
-   * \note The end event will contain an boolean as it's data, it will either
+   * \note The end event will contain an boolean as its data, it will either
    *       be true (update available) or false (no update for you).
    * \note Any error event that occurs will cancel this operation.
    */

--- a/components/devices/base/src/sbDeviceLibraryHelpers.cpp
+++ b/components/devices/base/src/sbDeviceLibraryHelpers.cpp
@@ -230,7 +230,7 @@ namespace
 
     /**
      * This updates the origin is in main library property in batch mode using
-     * it's own object for the enumeration.
+     * its own object for the enumeration.
      */
     NS_SCRIPTABLE NS_IMETHOD RunBatched(nsISupports *)
     {

--- a/components/devices/base/src/sbDeviceLibraryMediaSyncSettings.h
+++ b/components/devices/base/src/sbDeviceLibraryMediaSyncSettings.h
@@ -42,7 +42,7 @@ class sbDeviceLibrarySyncSettings;
 class sbDeviceLibraryMediaSyncSettings : public sbIDeviceLibraryMediaSyncSettings
 {
 public:
-  // This allows our owner to much with us within it's lock
+  // This allows our owner to much with us within its lock
   friend class sbDeviceLibrarySyncSettings;
   NS_DECL_ISUPPORTS
   NS_DECL_SBIDEVICELIBRARYMEDIASYNCSETTINGS;

--- a/components/devices/cd/src/sbCDDevice.h
+++ b/components/devices/cd/src/sbCDDevice.h
@@ -172,7 +172,7 @@ public:
   virtual PRBool IsRequestAborted();
 private:
   /**
-   * Protects the mProperites member and updating it's contents
+   * Protects the mProperites member and updating its contents
    */
   PRMonitor* mPropertiesLock;
 

--- a/components/devices/device/src/sbDeviceSupportsItemHelper.h
+++ b/components/devices/device/src/sbDeviceSupportsItemHelper.h
@@ -67,7 +67,7 @@ protected:
   nsCOMPtr<sbIMediaItem> mItem;
   nsCOMPtr<sbIDeviceSupportsItemCallback> mCallback;
 
-  // mDevice can't be a nsRefPtr because it's multiply derived from nsISupports
+  // mDevice can't be a nsRefPtr because it's derived multiply from nsISupports
   // and the two possibilities of AddRef confuses MSVC
   sbBaseDevice* mDevice;
 

--- a/components/devices/firmware/src/sbBaseDeviceFirmwareHandler.cpp
+++ b/components/devices/firmware/src/sbBaseDeviceFirmwareHandler.cpp
@@ -725,7 +725,7 @@ sbBaseDeviceFirmwareHandler::OnRecover(sbIDeviceFirmwareUpdate *aFirmwareUpdate)
   * firmware image.
   *
   * If no firmware update object is passed, the handler
-  * is expected to use a firmware update it packaged as part of it's add-on.
+  * is expected to use a firmware update it packaged as part of its add-on.
   * This is to enable a device to always be recovered even if the user is
   * off line or has never updated their firmware before and have no firmware
   * update present in their cache.

--- a/components/devices/firmware/src/sbDeviceFirmwareDownloader.cpp
+++ b/components/devices/firmware/src/sbDeviceFirmwareDownloader.cpp
@@ -1144,7 +1144,7 @@ sbDeviceFirmwareDownloader::HandleComplete()
     }
   }
 
-  // Move the file to it's resting place.
+  // Move the file to its resting place.
   nsCOMPtr<nsIFile> file;
   rv = mDownloader->GetDestinationFile(getter_AddRefs(file));
   NS_ENSURE_SUCCESS(rv, rv);

--- a/components/devices/firmware/src/sbDeviceFirmwareUpdater.cpp
+++ b/components/devices/firmware/src/sbDeviceFirmwareUpdater.cpp
@@ -1110,7 +1110,7 @@ sbDeviceFirmwareUpdater::GetHandler(sbIDevice *aDevice,
     // We assume there is only one device firmware handler
     // that can handle a device. In the future this may be
     // extended to put the handlers to a vote so that we may
-    // pick the one that's most certain about it's ability to
+    // pick the one that's most certain about its ability to
     // handle the device.
     if(canHandleDevice) {
       handler.forget(_retval);

--- a/components/devicesobsolete/base/public/sbIDeviceBase.idl
+++ b/components/devicesobsolete/base/public/sbIDeviceBase.idl
@@ -239,7 +239,7 @@ interface sbIDeviceBase : nsISupports
    *
    * Get a transfer location for the specified media item. This enables
    * the device to determine where best to put this media item based on 
-   * it's own set of criteria.
+   * its own set of criteria.
    *
    * \param aDeviceIdentifier The device unique identifier.
    * \param aMediaItem The media item that is about to be transferred.

--- a/components/devicesobsolete/download/src/DownloadDevice.cpp
+++ b/components/devicesobsolete/download/src/DownloadDevice.cpp
@@ -874,7 +874,7 @@ NS_IMETHODIMP sbDownloadDevice::GetDeviceState(
  *
  * Get a transfer location for the specified media item. This enables
  * the device to determine where best to put this media item based on
- * it's own set of criteria.
+ * its own set of criteria.
  *
  * \param aDeviceIdentifier The device unique identifier.
  * \param aMediaItem The media item that is about to be transferred.

--- a/components/devicesobsolete/download/src/DownloadDevice.cpp
+++ b/components/devicesobsolete/download/src/DownloadDevice.cpp
@@ -2752,7 +2752,7 @@ nsresult sbDownloadSession::Initiate()
       if (NS_FAILED(rv))
       {
         NS_WARNING("Failed to set originURL, this item may be duplicated later \
-                    because it's origin cannot be tracked!");
+                    because its origin cannot be tracked!");
         return rv;
       }
     }

--- a/components/filesystemevents/base/src/sbFileSystemTree.h
+++ b/components/filesystemevents/base/src/sbFileSystemTree.h
@@ -168,7 +168,7 @@ protected:
   // \brief This method looks at all the current directory entries and
   //        generates a change log of all the differences between the
   //        children that are currently stored in |aNode|.
-  // \param aNode The path node that is used for comparing it's children
+  // \param aNode The path node that is used for comparing its children
   //              against.
   // \param aNodePath The absolute path of the |aNode|.
   // \param aOutChangeArray The arrary of changes (as nodes) found during 

--- a/components/integration/public/sbIKnownFolderManager.idl
+++ b/components/integration/public/sbIKnownFolderManager.idl
@@ -34,9 +34,9 @@
 interface sbIKnownFolderManager : nsISupports 
 {
   /**
-   * \brief Get the localized display name of the folder based on it's path.
+   * \brief Get the localized display name of the folder based on its path.
    * 
-   * Get the localicazed display name of the folder based on it's path.
+   * Get the localicazed display name of the folder based on its path.
    * For folders that are not 'known folders' this will return the leaf part
    * of the path.
    * 

--- a/components/library/base/public/sbIMediaList.idl
+++ b/components/library/base/public/sbIMediaList.idl
@@ -398,7 +398,7 @@ interface sbIMediaList : sbIMediaItem
   /*
   Method: getItemByGuid()
 
-  Get a <MediaItem> from the <MediaList> by using it's <MediaItem::guid>.
+  Get a <MediaItem> from the <MediaList> by using its <MediaItem::guid>.
 
   Prototype:
     <MediaItem> getItemByGuid(String guid);
@@ -448,7 +448,7 @@ interface sbIMediaList : sbIMediaItem
   /*
   Method: getItemByIndex()
 
-  Get a <MediaItem> from the <MediaList> by using it's index in the <MediaList>.
+  Get a <MediaItem> from the <MediaList> by using its index in the <MediaList>.
 
   Prototype:
     <MediaItem> getItemByIndex(Number index)
@@ -1039,7 +1039,7 @@ interface sbIMediaList : sbIMediaItem
     //Remove the first occurrence of the mediaitem.
     mediaList.remove(mediaItem);
 
-    ... //Now only the second occurrence remains and it's index is now 0.
+    ... //Now only the second occurrence remains and its index is now 0.
     (end)
 
   See Also:
@@ -1057,7 +1057,7 @@ interface sbIMediaList : sbIMediaItem
   /*
   Method: removeByIndex()
 
-  Remove a <MediaItem> from the <MediaList> using it's index.
+  Remove a <MediaItem> from the <MediaList> using its index.
 
   Prototype:
     removeByIndex(Number index)

--- a/components/library/base/src/sbLibraryUtils.jsm
+++ b/components/library/base/src/sbLibraryUtils.jsm
@@ -891,7 +891,7 @@ LibraryUtils.GlobalMediaListListener.prototype = {
  * presence of the device ID property means we're dealing with an MTP
  * device
  * TODO: XXX Remove this function when x-mtp channel lands and replace
- * it's calls with item.userEditable
+ * its calls with item.userEditable
  */
 LibraryUtils.canEditMetadata = function (aItem) {
   var editable = aItem.userEditable;

--- a/components/library/localdatabase/src/sbLocalDatabaseDiffingService.cpp
+++ b/components/library/localdatabase/src/sbLocalDatabaseDiffingService.cpp
@@ -563,7 +563,7 @@ MarkLists(sbLDBDSEnumerator * aSrc, sbLDBDSEnumerator * aDest)
                                     destOriginEnd,
                                     &sbLDBDSEnumerator::ItemInfo::mOriginID);
 
-    // If found then we're mark the destination as an update and get it's ID
+    // If found then we're mark the destination as an update and get its ID
     nsID foundDestID;
     bool found = false;
     if (destOriginIter != destOriginEnd) {
@@ -595,7 +595,7 @@ MarkLists(sbLDBDSEnumerator * aSrc, sbLDBDSEnumerator * aDest)
       }
     }
     // If we found a match in the destination then we need to update the
-    // source, setting it's mAction and setting the origin back to the
+    // source, setting its mAction and setting the origin back to the
     // to the destination
     if (found) {
       // Origin in source becomes destination GUID

--- a/components/library/localdatabase/src/sbLocalDatabaseGUIDArray.cpp
+++ b/components/library/localdatabase/src/sbLocalDatabaseGUIDArray.cpp
@@ -1155,7 +1155,7 @@ sbLocalDatabaseGUIDArray::GetFirstIndexByGuid(const nsAString& aGuid,
 }
 
 /* aViewItemUID is a concatenation of a mediaitems rowid and mediaitemid from
- * it's entry in the library's database of the form "rowid-mediaitemid" */
+ * its entry in the library's database of the form "rowid-mediaitemid" */
 NS_IMETHODIMP
 sbLocalDatabaseGUIDArray::GetIndexByViewItemUID
                           (const nsAString& aViewItemUID,
@@ -2392,7 +2392,7 @@ sbLocalDatabaseGUIDArray::GetByIndexInternal(PRUint32 aIndex,
   }
 #else
   /*
-   * Cache miss, cache all GUIDs. FetchRows takes care of it's own locking.
+   * Cache miss, cache all GUIDs. FetchRows takes care of its own locking.
    */
   rv = FetchRows(0, 0);
   NS_ENSURE_SUCCESS(rv, rv);

--- a/components/mediacore/base/public/sbIMediacoreEvent.idl
+++ b/components/mediacore/base/public/sbIMediacoreEvent.idl
@@ -105,7 +105,7 @@ interface sbIMediacoreEvent : nsISupports
    * \brief Sequence end.
    *
    * This event will be fired by the sequencer when it runs
-   * out of items to play from it's sequence. This event will
+   * out of items to play from its sequence. This event will
    * not be fired when the sequence repeats because of repeat
    * one or repeat all being turned on.
    *
@@ -248,7 +248,7 @@ interface sbIMediacoreEvent : nsISupports
   const unsigned long CUSTOM_EVENT_BASE = 0x40000000;
 
   /**
-   * \brief Indicates the event is an error and will have it's error member set.
+   * \brief Indicates the event is an error and will have its error member set.
    */
   const unsigned long ERROR_EVENT       = 0x80000000;
 

--- a/components/mediacore/gstreamer/src/sbGStreamerTranscode.cpp
+++ b/components/mediacore/gstreamer/src/sbGStreamerTranscode.cpp
@@ -264,7 +264,7 @@ sbGStreamerTranscode::BuildPipeline()
     goto done;
   }
 
-  // We have a pipeline, set it's main operation to transcoding.   
+  // We have a pipeline, set its main operation to transcoding.   
   SetPipelineOp(GStreamer::OP_TRANSCODING);
 
   tags = ConvertPropertyArrayToTagList(mMetadata);

--- a/components/mediaexport/src/sbMediaExportService.cpp
+++ b/components/mediaexport/src/sbMediaExportService.cpp
@@ -1168,7 +1168,7 @@ sbMediaExportService::OnItemAdded(sbIMediaList *aMediaList,
     sbMediaListItemMapIter guidIter = mAddedItemsMap.find(listGuid);
     if (guidIter == mAddedItemsMap.end()) {
       // The media list isn't represented in the map, add a new entry for this
-      // media list using it's guid.
+      // media list using its guid.
       std::pair<sbMediaListItemMapIter, bool> insertedPair =
         mAddedItemsMap.insert(sbMediaListItemMapPair(listGuid, sbStringList()));
 

--- a/components/playlistcommands/src/sbPlaylistCommandsHelper.cpp
+++ b/components/playlistcommands/src/sbPlaylistCommandsHelper.cpp
@@ -548,7 +548,7 @@ sbPlaylistCommandsHelper::RemoveCommandObject
                                                       aMediaListType,
                                                       aCommandObject);
     NS_ENSURE_SUCCESS(rv, rv);
-    // unregister does it's own onCommandRemoved signal, so no need here
+    // unregister does its own onCommandRemoved signal, so no need here
   }
 
   // if we want to remove from the context menu and toolbar, we can do that now
@@ -564,7 +564,7 @@ sbPlaylistCommandsHelper::RemoveCommandObject
                                                       aMediaListType,
                                                       aCommandObject);
     NS_ENSURE_SUCCESS(rv, rv);
-    // unregister does it's own onCommandRemoved signal, so no need here
+    // unregister does its own onCommandRemoved signal, so no need here
 
     rv = SetRemainingFlags(aTargetFlags, aCommandObject);
     NS_ENSURE_SUCCESS(rv, rv);
@@ -666,7 +666,7 @@ sbPlaylistCommandsHelper::RemoveCommandObject
                                                         aMediaListType,
                                                         aCommandObject);
       NS_ENSURE_SUCCESS(rv, rv);
-      // unregister does it's own onCommandRemoved signal, so no need here
+      // unregister does its own onCommandRemoved signal, so no need here
     }
   }
   rv = SetRemainingFlags(aTargetFlags, aCommandObject);

--- a/components/remoteapi/public/sbIRemoteLibrary.idl
+++ b/components/remoteapi/public/sbIRemoteLibrary.idl
@@ -115,7 +115,7 @@ interface sbIRemoteLibrary : nsISupports
    *
    * This attribute controlls whether or not the library will cause the
    *   metadata to be scanned for any tracks created. If a website wants
-   *   to hand-set it's metadata then it should set this to false. By
+   *   to hand-set its metadata then it should set this to false. By
    *   default this is true. If metadat for a particular track has already
    *   been scanned, that metadata will show up automatically ( for instance
    *   for 2 items created from the same URL ).

--- a/components/remoteapi/public/sbIRemotePlayer.idl
+++ b/components/remoteapi/public/sbIRemotePlayer.idl
@@ -961,7 +961,7 @@ interface sbIRemotePlayer : nsISupports
                                                     in long aStatus);
 
   /**
-   * \brief Forces the webplaylist to rescan it's commands
+   * \brief Forces the webplaylist to rescan its commands
    */
   [noscript] void onCommandsChanged();
 

--- a/components/remoteapi/public/sbIRemoteSecurityEvent.idl
+++ b/components/remoteapi/public/sbIRemoteSecurityEvent.idl
@@ -94,7 +94,7 @@ Example:
 
     if ( aEvent.type == 'RemoteAPIPermissionDenied' ) {
       msg = "You have opted to not configure Songbird so our webpage can interact " +
-            "with it at it's fullest. Please open tools->options and configure the " +
+            "with it at its fullest. Please open tools->options and configure the " +
             "RemoteAPI preferences to allow us XYZ permissions. " + 
             "Below are the permissions that were requested.";
             

--- a/components/remoteapi/src/sbRemoteMediaListBase.cpp
+++ b/components/remoteapi/src/sbRemoteMediaListBase.cpp
@@ -261,7 +261,7 @@ sbRemoteMediaListBase::ThrowJSException( JSContext *cx,
  *
  * We are argc agnostic here, so if you pass in more than 2 args
  *   we ignore them and if the second arg isn't a media item (QI-able to
- *   sbIMediaItem) then we convert it to it's boolean representation and use
+ *   sbIMediaItem) then we convert it to its boolean representation and use
  *   it as an arg to determine if we should download. We only hard fail in the
  *   case of:
  *

--- a/components/remoteapi/test/test-remoteAPI_07.html
+++ b/components/remoteapi/test/test-remoteAPI_07.html
@@ -110,7 +110,7 @@
   </head>
   <body onunload="document.removeEventListener('remoteapi', onRemoteAPI, true);">
     <h1>RemoteCommand registration, object access, callbacks</h1>
-    <p> create a remoteCommand, get callbacks for it's events and see
+    <p> create a remoteCommand, get callbacks for its events and see
         callbacks happen. </p>
     <br />
     <p> Force a web playlist to appear. <br />

--- a/components/remoteapi/test/test-remoteAPI_hatNotification.html
+++ b/components/remoteapi/test/test-remoteAPI_hatNotification.html
@@ -75,7 +75,7 @@
       function handleEvent(aEvent) {
         if ( aEvent.type == 'RemoteAPIPermissionDenied' ) {
           msg = "You have opted to not configure Songbird so our webpage can interact " +
-                "with it at it's fullest. Please open tools->options and configure the " +
+                "with it at its fullest. Please open tools->options and configure the " +
                 "RemoteAPI preferences to allow us XYZ permissions. " + 
                 "Below are the permissions that were requested.";
                 

--- a/components/remoteapi/test/test_properties_page.html
+++ b/components/remoteapi/test/test_properties_page.html
@@ -345,7 +345,7 @@ function runTest(tester) {
         // main library is all readonly
         if ( obj == "library" ) {
           try {
-            // library has it's mediaListName set specifically
+            // library has its mediaListName set specifically
             if ( stuff == "mediaListName" ) {
               var val = foo.getProperty(props[stuff]);
               tester.assertEqual( val, "&chrome://songbird/locale/songbird.properties#servicesource.library" );

--- a/components/servicepane/src/sbDeviceServicePaneService.js
+++ b/components/servicepane/src/sbDeviceServicePaneService.js
@@ -319,7 +319,7 @@ function sbDeviceServicePane_createLibraryNodeForDevice(aDevice, aLibrary) {
 
   /* Add a listener to detect when a device library item's originItemGuid
    * property is updated.
-   * We use this listener to detect when a medialist has it's originItemGuid
+   * We use this listener to detect when a medialist has its originItemGuid
    * changed which will occur when the medialist is imporpied into the main
    * library and will likely mean we should remove its 'deviceonly' icon */
   var deviceUpdateListener = new DeviceLibraryItemUpdateListener();
@@ -396,9 +396,9 @@ function sbDeviceServicePane_insertChildByName(aDevice, aChild) {
   // If we are inserting a medialist node, check if it is deviceonly
   if (aChild.className.match(/medialist/) != null) {
 
-    /* The node looks like a medialist.  We'll get it's resource, check that
+    /* The node looks like a medialist.  We'll get its resource, check that
      * it's a medialist, and look for an item in the mainLibrary that has a
-     * guid matching it's originGUID.  If we can't find one, we'll label the
+     * guid matching its originGUID.  If we can't find one, we'll label the
      * node as representing a deviceonly medialist */
     var resource = this._libraryServicePane.getLibraryResourceForNode(aChild);
     if (resource instanceof Ci.sbIMediaList &&

--- a/components/testharness/basetests/head_songbird.js
+++ b/components/testharness/basetests/head_songbird.js
@@ -759,12 +759,12 @@ function newFileURI(file)
  *   };
  *
  *   var playlist = makeMeAPlaylist();
- *   // here, playlist.getNextSong() has it's original behavior
+ *   // here, playlist.getNextSong() has its original behavior
  *   var testCase = new TestCase(testConfig);
  *   // Prior to execution of the test case, playlist.getNextSong() will
  *   // be modified to invoke the stubbed function
  *   testCase.run([playlist]);
- *   // here, playlist.getNextSong() has it's original behavior again
+ *   // here, playlist.getNextSong() has its original behavior again
  */
 function TestCase(config) {
 

--- a/components/watchfolder/test/test_moverename.js
+++ b/components/watchfolder/test/test_moverename.js
@@ -56,7 +56,7 @@ function runTest () {
   // That should cause watch folders to add the files...
   sleep(15000);
   
-  // Mark each item with it's original url, so we
+  // Mark each item with its original url, so we
   // can tell they update correctly
   library.enumerateAllItems({
      onEnumerationBegin: function(list) {

--- a/documentation/lists/MetadataOverwrite.md
+++ b/documentation/lists/MetadataOverwrite.md
@@ -1,7 +1,7 @@
 Metadata Updates
 ================
 
-When a [MediaItem](@ref sbIMediaItem) gets played, it's metadata may change because the playback
+When a [MediaItem](@ref sbIMediaItem) gets played, its metadata may change because the playback
 core is offering new metadata about this [MediaItem](@ref sbIMediaItem) that wasn't available when
 metadata was first read from it because it was added to a Library.
 

--- a/extensions/qatesttools/chrome/content/playlistInfoDialog.xul
+++ b/extensions/qatesttools/chrome/content/playlistInfoDialog.xul
@@ -339,7 +339,7 @@
           infoBox = infoBox.parentNode;
         }
 
-        // Get the medialist dropdown to retrieve information about it's
+        // Get the medialist dropdown to retrieve information about its
         // current selection
         var mediaListMenu = infoBox.getElementsByAttribute
                                    ("class", "name-box")[0].firstChild;

--- a/tools/common/naturaldocs/Info/CSSGuide.txt
+++ b/tools/common/naturaldocs/Info/CSSGuide.txt
@@ -163,9 +163,9 @@ Topic: Content Structure
 
                 <CBody>
 
-                    <ClassHierarchy> (See it's section)
+                    <ClassHierarchy> (See its section)
 
-                    <Prototype> (See it's section)
+                    <Prototype> (See its section)
 
                     <p CParagraph>
                          Paragraph
@@ -196,7 +196,7 @@ Topic: Content Structure
                         </tr>
                     </table CDescriptionList>
 
-                    <Summary> (See it's section)
+                    <Summary> (See its section)
 
                </CBody>
 

--- a/tools/common/naturaldocs/Modules/NaturalDocs/File.pm
+++ b/tools/common/naturaldocs/Modules/NaturalDocs/File.pm
@@ -471,7 +471,7 @@ sub CreatePath #(path)
 #
 #   Parameters:
 #
-#       path - The path to start from.  It will try to remove this directory and work it's way down.
+#       path - The path to start from.  It will try to remove this directory and work its way down.
 #       limit - The path to stop at if it doesn't find any non-empty directories first.  This path will *not* be removed.
 #
 sub RemoveEmptyTree #(path, limit)

--- a/tools/common/naturaldocs/Modules/NaturalDocs/Parser/ParsedTopic.pm
+++ b/tools/common/naturaldocs/Modules/NaturalDocs/Parser/ParsedTopic.pm
@@ -142,7 +142,7 @@ sub Symbol
 #
 #       - If the <TopicType> has scope, the package will be generated from both the title and the package passed to <New()>, not
 #         just the package.
-#       - If the <TopicType> is always global, the package will be the one passed to <New()>, even though it isn't part of it's
+#       - If the <TopicType> is always global, the package will be the one passed to <New()>, even though it isn't part of its
 #         <Symbol()>.
 #       - Everything else's package will be what was passed to <New()>, even if the title has separator symbols in it.
 #

--- a/tools/common/naturaldocs/Modules/NaturalDocs/Topics.pm
+++ b/tools/common/naturaldocs/Modules/NaturalDocs/Topics.pm
@@ -36,7 +36,7 @@ our @EXPORT = ( 'TOPIC_GENERAL', 'TOPIC_GENERIC', 'TOPIC_GROUP', 'TOPIC_CLASS', 
 #
 #   Type: TopicType
 #
-#   A string representing a topic type as defined in <Topics.txt>.  It's format should be treated as opaque; use <MakeTopicType()>
+#   A string representing a topic type as defined in <Topics.txt>.  Its format should be treated as opaque; use <MakeTopicType()>
 #   to get them from topic names.  However, they can be compared for equality with string functions.
 #
 


### PR DESCRIPTION
A grammar mistake in the first window that the user sees seems unprofessional.

![screen shot 2015-09-13 at 10 16 52 am](https://cloud.githubusercontent.com/assets/583459/9837067/db27b696-5a00-11e5-921a-62675e3d40f5.png)

I patched the license text into terms I could accept.
